### PR TITLE
docs: update API documentation for Apollo Federation architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,46 @@
 # 💰 Wallet Platform
 
-Мікросервісна платформа для управління цифровими гаманцями з використанням NestJS, GraphQL, MongoDB та RabbitMQ.
+Мікросервісна платформа для управління цифровими гаманцями з використанням Apollo Federation, NestJS, GraphQL, MongoDB та RabbitMQ.
 
 ## 🏗️ Архітектура
 
 ```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Auth Service  │    │  User Service   │    │ Wallet Service  │
-│     (5000)      │    │     (5001)      │    │     (5002)      │
-│   GraphQL API   │    │   REST API      │    │   REST API      │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-         │                       │                       │
-         └───────────────────────┼───────────────────────┘
-                                 │
-                    ┌─────────────────┐
-                    │   RabbitMQ      │
-                    │    (5672)       │
-                    │   Management    │
-                    │    (15672)      │
-                    └─────────────────┘
-                                 │
-         ┌───────────────────────┼───────────────────────┐
-         │                       │                       │
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   MongoDB       │    │   MongoDB       │    │   MongoDB       │
-│   Auth DB       │    │   Users DB      │    │  Wallets DB     │
-│   (27017)       │    │   (27017)       │    │   (27017)       │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
+                    ┌─────────────────────┐
+                    │  Gateway Service    │
+                    │      (4000)         │
+                    │  Apollo Federation  │
+                    │   GraphQL Gateway   │
+                    └─────────────────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         │                   │                   │
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   Auth Service  │  │  User Service   │  │ Wallet Service  │
+│     (3000)      │  │     (3001)      │  │     (3002)      │
+│  GraphQL + JWT  │  │   GraphQL API   │  │   GraphQL API   │
+└─────────────────┘  └─────────────────┘  └─────────────────┘
+         │                   │                   │
+         │                   └─────────┼─────────┘
+         │                             │
+         │              ┌─────────────────────┐
+         │              │     RabbitMQ        │
+         │              │      (5672)         │
+         │              │   Management UI     │
+         │              │     (15672)         │
+         │              └─────────────────────┘
+         │                             │
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   MongoDB       │  │   MongoDB       │  │   MongoDB       │
+│   Auth DB       │  │   Users DB      │  │  Wallets DB     │
+│   (27017)       │  │   (27018)       │  │   (27019)       │
+└─────────────────┘  └─────────────────┘  └─────────────────┘
+         │                   │                   │
+         └─────────────────  │  ─────────────────┘
+                    ┌─────────────────────┐
+                    │      Redis          │
+                    │      (6379)         │
+                    │   Session Store     │
+                    └─────────────────────┘
 ```
 
 ## 🚀 Швидкий старт
@@ -44,55 +58,74 @@
 git clone <repository-url>
 cd wallet-platform
 
+# Створення .env файлу
+cp env.example .env
+
 # Запуск всіх сервісів
-docker-compose up --build -d
+docker-compose -f docker-compose.dev.yml up -d
 
 # Перевірка статусу
-docker ps
+docker-compose -f docker-compose.dev.yml ps
 ```
 
 ### Перевірка роботи
 
 ```bash
-# Auth Service (GraphQL)
-curl -X POST http://localhost:5000/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query { ping }"}'
+# Gateway Service - єдина точка входу для всіх GraphQL запитів
+curl http://localhost:4000/graphql
 
-# User Service
-curl http://localhost:5001/health
+# Окремі сервіси (для перевірки)
+curl http://localhost:3000        # Auth Service: "Auth Service is running!"
+curl http://localhost:3001        # User Service: "User Service is running!"
+curl http://localhost:3002        # Wallet Service: "Wallet Service is running!"
 
-# Wallet Service
-curl http://localhost:5002/health
+# Health endpoints
+curl http://localhost:3000/health # Auth Service health
+curl http://localhost:3001/health # User Service health
+curl http://localhost:3002/health # Wallet Service health
 
 # RabbitMQ Management UI
-http://localhost:15672 (admin/password)
+http://localhost:15672 (dev_user/dev_password)
 ```
 
 ## 📋 Сервіси
 
-| Сервіс             | Порт | Технології                      | Опис                          |
-| ------------------ | ---- | ------------------------------- | ----------------------------- |
-| **Auth Service**   | 5000 | NestJS, GraphQL, JWT, MongoDB   | Автентифікація та авторизація |
-| **User Service**   | 5001 | NestJS, REST, MongoDB, RabbitMQ | Управління користувачами      |
-| **Wallet Service** | 5002 | NestJS, REST, MongoDB, RabbitMQ | Управління гаманцями          |
+| Сервіс              | Порт | Технології                         | Опис                                 |
+| ------------------- | ---- | ---------------------------------- | ------------------------------------ |
+| **Gateway Service** | 4000 | NestJS, Apollo Federation, GraphQL | Єдина точка входу, об'єднує всі API  |
+| **Auth Service**    | 3000 | NestJS, GraphQL, JWT, MongoDB      | Автентифікація та авторизація        |
+| **User Service**    | 3001 | NestJS, GraphQL, MongoDB, RabbitMQ | Управління користувачами             |
+| **Wallet Service**  | 3002 | NestJS, GraphQL, MongoDB, RabbitMQ | Управління гаманцями та транзакціями |
 
 ## 🔗 Endpoints
 
-### Auth Service (GraphQL)
+### 🌟 Gateway Service (Головний API)
 
-- **URL**: http://localhost:5000/graphql
-- **Playground**: http://localhost:5000/graphql (у браузері)
+- **URL**: http://localhost:4000/graphql
+- **Playground**: http://localhost:4000/graphql (у браузері)
 
-**Приклади запитів:**
+**Особливості:**
+
+- Єдина точка входу для всіх GraphQL запитів
+- Apollo Federation - автоматично об'єднує схеми всіх сервісів
+- JWT авторизація та передача контексту між сервісами
+- Introspection та Playground доступні в development режимі
+
+### 🔐 Auth Service
+
+- **URL**: http://localhost:3000/graphql
+- **Health**: http://localhost:3000/health
+- **Status**: http://localhost:3000 → "Auth Service is running!"
+
+**Доступні операції:**
 
 ```graphql
-# Ping
+# Ping перевірка
 query {
   ping
 }
 
-# Реєстрація
+# Реєстрація користувача
 mutation {
   register(
     input: {
@@ -107,7 +140,7 @@ mutation {
   }
 }
 
-# Вхід
+# Авторизація
 mutation {
   login(input: { email: "user@example.com", password: "password123" }) {
     accessToken
@@ -117,23 +150,113 @@ mutation {
 }
 ```
 
-### User Service (REST)
+### 👤 User Service
 
-- **URL**: http://localhost:5001
-- **Health**: `GET /health`
+- **URL**: http://localhost:3001/graphql
+- **Health**: http://localhost:3001/health
+- **Status**: http://localhost:3001 → "User Service is running!"
 
-### Wallet Service (REST)
+**Доступні операції:**
 
-- **URL**: http://localhost:5002
-- **Health**: `GET /health`
+```graphql
+# Створення користувача
+mutation {
+  createUser(
+    createUserInput: {
+      email: "user@example.com"
+      firstName: "John"
+      lastName: "Doe"
+      phone: "+1234567890"
+    }
+  ) {
+    id
+    email
+    firstName
+    lastName
+    isActive
+  }
+}
+
+# Отримання користувачів
+query {
+  users {
+    id
+    email
+    firstName
+    lastName
+  }
+}
+```
+
+### 💰 Wallet Service
+
+- **URL**: http://localhost:3002/graphql
+- **Health**: http://localhost:3002/health
+- **Status**: http://localhost:3002 → "Wallet Service is running!"
+
+**Доступні операції:**
+
+```graphql
+# Створення гаманця
+mutation {
+  createWallet(createWalletInput: { userId: "USER_ID", currency: USD }) {
+    id
+    userId
+    walletNumber
+    balance
+    currency
+    status
+  }
+}
+
+# Поповнення гаманця
+mutation {
+  topUpWallet(
+    topUpInput: { walletId: "WALLET_ID", amount: 100.00, description: "Top up" }
+  ) {
+    id
+    balance
+  }
+}
+
+# Переказ між гаманцями
+mutation {
+  transferBetweenWallets(
+    transferInput: {
+      fromWalletId: "FROM_WALLET_ID"
+      toWalletId: "TO_WALLET_ID"
+      amount: 50.00
+      description: "Transfer"
+    }
+  ) {
+    id
+    type
+    amount
+    status
+  }
+}
+```
 
 ## 🗄️ База даних
 
 Проект використовує окремі MongoDB інстанси для кожного сервісу:
 
 - **mongo-auth**: Дані автентифікації (порт 27017)
-- **mongo-users**: Дані користувачів (порт 27017)
-- **mongo-wallets**: Дані гаманців (порт 27017)
+- **mongo-users**: Дані користувачів (порт 27018)
+- **mongo-wallets**: Дані гаманців (порт 27019)
+
+**Підключення до БД:**
+
+```bash
+# Auth DB
+mongosh mongodb://dev_user:dev_password@localhost:27017/auth-service
+
+# Users DB
+mongosh mongodb://dev_user:dev_password@localhost:27018/user-service
+
+# Wallets DB
+mongosh mongodb://dev_user:dev_password@localhost:27019/wallet-service
+```
 
 ## 🐰 Message Queue
 
@@ -141,7 +264,17 @@ mutation {
 
 - **AMQP**: localhost:5672
 - **Management UI**: http://localhost:15672
-- **Credentials**: admin/password
+- **Credentials**: dev_user/dev_password
+- **Virtual Host**: wallet_platform
+
+**Події (Events):**
+
+- `user.created` - користувач створений (user-service → wallet-service)
+- `user.updated` - користувач оновлений
+- `user.deleted` - користувач видалений
+- `wallet.created` - гаманець створений
+- `wallet.topped_up` - гаманець поповнений
+- `wallet.transferred` - переказ між гаманцями
 
 ## 🛠️ Розробка
 
@@ -165,97 +298,199 @@ npm run test:e2e
 ### Корисні команди
 
 ```bash
-# Перегляд логів
-docker-compose logs -f auth-service
+# Перегляд логів всіх сервісів
+docker-compose -f docker-compose.dev.yml logs -f
+
+# Перегляд логів конкретного сервісу
+docker-compose -f docker-compose.dev.yml logs -f gateway-service
+docker-compose -f docker-compose.dev.yml logs -f auth-service
+docker-compose -f docker-compose.dev.yml logs -f user-service
+docker-compose -f docker-compose.dev.yml logs -f wallet-service
 
 # Перезапуск сервісу
-docker-compose restart auth-service
+docker-compose -f docker-compose.dev.yml restart auth-service
 
 # Зупинка всіх сервісів
-docker-compose down
+docker-compose -f docker-compose.dev.yml down
 
 # Очистка volumes (ОБЕРЕЖНО!)
-docker-compose down -v
+docker-compose -f docker-compose.dev.yml down -v
 
 # Білд без кешу
-docker-compose build --no-cache
+docker-compose -f docker-compose.dev.yml build --no-cache
+
+# Запуск тільки основних сервісів (без моніторингу)
+docker-compose -f docker-compose.dev.yml up mongo-auth mongo-users mongo-wallets redis rabbitmq auth-service user-service wallet-service gateway-service -d
 ```
 
 ## 📁 Структура проекту
 
 ```
 wallet-platform/
-├── docker-compose.yml           # Основна конфігурація Docker
+├── docker-compose.yml           # Production конфігурація
+├── docker-compose.dev.yml       # Development конфігурація
+├── env.example                 # Приклад змінних середовища
 ├── README.md                   # Ця документація
+├── scripts/                    # Допоміжні скрипти
+│   ├── init-mongo-auth.js     # Ініціалізація MongoDB для auth
+│   ├── start-dev.bat          # Windows запуск
+│   └── start-dev.sh           # Unix запуск
 ├── services/
+│   ├── gateway-service/       # Apollo Federation Gateway
+│   │   ├── src/
+│   │   │   ├── app.module.ts
+│   │   │   ├── auth/          # JWT стратегія
+│   │   │   ├── guards/        # Auth guards
+│   │   │   ├── decorators/    # Custom decorators
+│   │   │   └── examples/      # Приклади використання
+│   │   ├── Dockerfile.dev
+│   │   └── package.json
 │   ├── auth-service/          # Сервіс автентифікації
 │   │   ├── src/
+│   │   │   ├── auth/          # GraphQL resolvers
+│   │   │   ├── users/         # User entities
+│   │   │   └── health/        # Health checks
 │   │   ├── test/
-│   │   ├── Dockerfile
+│   │   ├── Dockerfile.dev
 │   │   └── package.json
 │   ├── user-service/          # Сервіс користувачів
 │   │   ├── src/
+│   │   │   ├── users/         # User CRUD operations
+│   │   │   ├── messaging/     # RabbitMQ integration
+│   │   │   └── health/
 │   │   ├── test/
-│   │   ├── Dockerfile
+│   │   ├── Dockerfile.dev
 │   │   └── package.json
 │   └── wallet-service/        # Сервіс гаманців
 │       ├── src/
+│       │   ├── wallet/        # Wallet operations
+│       │   ├── wallets/       # Wallet entities
+│       │   ├── transactions/  # Transaction entities
+│       │   ├── messaging/     # RabbitMQ integration
+│       │   └── events/        # Event definitions
 │       ├── test/
-│       ├── Dockerfile
+│       ├── Dockerfile.dev
 │       └── package.json
 └── docs/                      # Документація
+    ├── API.md                 # API документація
+    ├── DOCKER.md              # Docker інструкції
+    └── TESTING_GRAPHQL.md     # Посібник з тестування
 ```
 
 ## 🧪 Тестування
+
+### 🎯 GraphQL Playground Тестування
+
+**Головний спосіб тестування - через Gateway Service:**
+
+1. Запустіть всі сервіси: `docker-compose -f docker-compose.dev.yml up -d`
+2. Відкрийте: http://localhost:4000/graphql
+3. Використовуйте повний посібник: [docs/TESTING_GRAPHQL.md](docs/TESTING_GRAPHQL.md)
+
+**Швидкий тест:**
+
+```graphql
+# 1. Реєстрація користувача
+mutation {
+  register(
+    input: {
+      email: "test@example.com"
+      password: "password123"
+      name: "Test User"
+    }
+  ) {
+    accessToken
+    userId
+    roles
+  }
+}
+
+# 2. Створення профілю (використайте токен в Headers)
+mutation {
+  createUser(
+    createUserInput: {
+      email: "test@example.com"
+      firstName: "Test"
+      lastName: "User"
+    }
+  ) {
+    id
+    email
+  }
+}
+
+# 3. Створення гаманця
+mutation {
+  createWallet(
+    createWalletInput: { userId: "USER_ID_FROM_STEP_2", currency: USD }
+  ) {
+    id
+    walletNumber
+    balance
+  }
+}
+```
 
 ### Unit тести
 
 ```bash
 # Всі сервіси
-npm test
-
-# Конкретний сервіс
 cd services/auth-service && npm test
-```
-
-### E2E тести
-
-```bash
-# Всі сервіси
-npm run test:e2e
+cd services/user-service && npm test
+cd services/wallet-service && npm test
+cd services/gateway-service && npm test
 
 # З coverage
 npm run test:cov
 ```
 
-### Integration тести
+### E2E тести
 
 ```bash
-# Запуск тестового оточення
-docker-compose -f docker-compose.test.yml up -d
-
-# Запуск тестів
-npm run test:integration
+# Конкретний сервіс
+cd services/auth-service && npm run test:e2e
+cd services/user-service && npm run test:e2e
+cd services/wallet-service && npm run test:e2e
 ```
 
 ## 🔧 Конфігурація
 
 ### Змінні середовища
 
-Створіть `.env` файл у корені проекту:
+Створіть `.env` файл у корені проекту (або скопіюйте з прикладу):
+
+```bash
+cp env.example .env
+```
+
+**Основні змінні:**
 
 ```env
-# JWT
-JWT_SECRET=your-super-secure-jwt-secret
+# JWT Configuration
+JWT_SECRET=your-super-secret-jwt-key-here
+JWT_EXPIRE=1h
 
-# RabbitMQ
-RABBITMQ_DEFAULT_USER=admin
-RABBITMQ_DEFAULT_PASS=your-secure-password
+# Gateway Service Configuration
+GATEWAY_PORT=4000
+AUTH_SERVICE_URL=http://auth-service:3000/graphql
+USER_SERVICE_URL=http://user-service:3001/graphql
+WALLET_SERVICE_URL=http://wallet-service:3002/graphql
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
-# MongoDB
-MONGO_AUTH_URI=mongodb://localhost:27017/auth
-MONGO_USERS_URI=mongodb://localhost:27017/users
-MONGO_WALLETS_URI=mongodb://localhost:27017/wallets
+# Database Configuration
+MONGO_URI_AUTH=mongodb://dev_user:dev_password@mongo-auth:27017/auth-service?authSource=admin
+MONGO_URI_USERS=mongodb://dev_user:dev_password@mongo-users:27017/user-service?authSource=admin
+MONGO_URI_WALLETS=mongodb://dev_user:dev_password@mongo-wallets:27017/wallet-service?authSource=admin
+
+# Redis Configuration
+REDIS_URL=redis://redis:6379
+
+# RabbitMQ Configuration
+RABBITMQ_URL=amqp://dev_user:dev_password@rabbitmq:5672/wallet_platform
+
+# Node Environment
+NODE_ENV=development
+LOG_LEVEL=debug
 ```
 
 ## 🚀 Деплой
@@ -274,11 +509,34 @@ docker-compose -f docker-compose.staging.yml up -d
 docker-compose -f docker-compose.prod.yml up -d
 ```
 
-## 📈 Моніторинг
+## 📈 Моніторинг та Спостереження
 
-- **Health Checks**: Автоматичні перевірки здоров'я сервісів
-- **Logs**: Централізовані логи через Docker
-- **Metrics**: Готовність до інтеграції з Prometheus/Grafana
+### Health Checks
+
+Всі сервіси мають автоматичні перевірки здоров'я:
+
+- **Gateway**: `wget http://localhost:4000/health`
+- **Auth**: `wget http://localhost:3000/health`
+- **User**: `wget http://localhost:3001/health`
+- **Wallet**: `wget http://localhost:3002/health`
+
+### Логи
+
+```bash
+# Всі сервіси
+docker-compose -f docker-compose.dev.yml logs -f
+
+# Фільтрування логів
+docker-compose -f docker-compose.dev.yml logs -f | grep ERROR
+docker-compose -f docker-compose.dev.yml logs -f auth-service | grep -i jwt
+```
+
+### Доступні інструменти моніторингу
+
+- **Prometheus**: `http://localhost:9090` (опціонально)
+- **Grafana**: `http://localhost:3000` (опціонально)
+- **Jaeger**: `http://localhost:16686` (опціонально)
+- **RabbitMQ Management**: `http://localhost:15672`
 
 ## 🤝 Розробка
 
@@ -299,12 +557,66 @@ docker-compose -f docker-compose.prod.yml up -d
 
 Private License - всі права захищені.
 
-## 👥 Команда
+## 🚨 Troubleshooting
 
-- Backend: NestJS + GraphQL + MongoDB
-- Message Queue: RabbitMQ
-- Infrastructure: Docker + Docker Compose
+### Поширені проблеми
+
+**1. Порт вже зайнятий**
+
+```bash
+# Перевірити що використовує порт
+netstat -ano | findstr ":3000 :3001 :3002 :4000"
+
+# Зупинити всі контейнери
+docker-compose -f docker-compose.dev.yml down
+```
+
+**2. Health check fails**
+
+```bash
+# Перевірити логи сервісу
+docker-compose -f docker-compose.dev.yml logs auth-service
+
+# Перевірити чи працює endpoint
+curl http://localhost:3000/health
+```
+
+**3. MongoDB connection failed**
+
+```bash
+# Перевірити статус MongoDB
+docker-compose -f docker-compose.dev.yml ps mongo-auth
+
+# Перезапустити з чистими volumes
+docker-compose -f docker-compose.dev.yml down -v
+docker-compose -f docker-compose.dev.yml up -d
+```
+
+**4. RabbitMQ connection issues**
+
+```bash
+# Перевірити RabbitMQ
+docker-compose -f docker-compose.dev.yml logs rabbitmq
+
+# Відкрити Management UI
+http://localhost:15672 (dev_user/dev_password)
+```
+
+## 👥 Стек технологій
+
+- **Backend**: NestJS + TypeScript
+- **API**: GraphQL + Apollo Federation
+- **Database**: MongoDB (окремі інстанси)
+- **Message Queue**: RabbitMQ
+- **Cache**: Redis
+- **Infrastructure**: Docker + Docker Compose
+- **Testing**: Jest + Supertest + GraphQL Playground
 
 ---
 
-**💡 Tip**: Для детальної документації кожного сервісу дивіться README файли у відповідних папках `services/`.
+**💡 Корисні посилання:**
+
+- [Повний посібник з тестування](docs/TESTING_GRAPHQL.md)
+- [API документація](docs/API.md)
+- [Docker інструкції](docs/DOCKER.md)
+- [README кожного сервісу](services/) - детальна документація

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,28 +1,38 @@
 # 📡 API Documentation
 
-Повна документація по API endpoints для всіх сервісів Wallet Platform.
+Повна документація по API endpoints для всіх сервісів Wallet Platform з Apollo Federation.
 
 ## 🌐 Base URLs
 
-| Service             | URL                    | Type    |
-| ------------------- | ---------------------- | ------- |
-| Auth Service        | http://localhost:5000  | GraphQL |
-| User Service        | http://localhost:5001  | REST    |
-| Wallet Service      | http://localhost:5002  | REST    |
-| RabbitMQ Management | http://localhost:15672 | Web UI  |
+| Service             | URL                    | Type    | Description                            |
+| ------------------- | ---------------------- | ------- | -------------------------------------- |
+| **Gateway Service** | http://localhost:4000  | GraphQL | **Головний API (використовуйте цей!)** |
+| Auth Service        | http://localhost:3000  | GraphQL | Прямий доступ (для розробки)           |
+| User Service        | http://localhost:3001  | GraphQL | Прямий доступ (для розробки)           |
+| Wallet Service      | http://localhost:3002  | GraphQL | Прямий доступ (для розробки)           |
+| RabbitMQ Management | http://localhost:15672 | Web UI  | Управління чергами повідомлень         |
 
-## 🔐 Auth Service (GraphQL)
+## 🌟 Gateway Service - Головний API
 
-### GraphQL Playground
+**URL**: http://localhost:4000/graphql  
+**Playground**: http://localhost:4000/graphql (у браузері)
 
-**URL**: http://localhost:5000/graphql
+### Особливості
 
-### Authentication Flow
+- **Apollo Federation** - автоматично об'єднує всі GraphQL схеми
+- **Єдина точка входу** для всіх операцій
+- **JWT авторизація** з автоматичною передачею контексту
+- **Introspection** та **Playground** в development режимі
+- **Оптимізація запитів** між сервісами
 
-#### 1. Register User
+## 🔐 Автентифікація та авторизація
+
+Всі операції автентифікації виконуються через Gateway Service.
+
+### 1. Реєстрація користувача
 
 ```graphql
-mutation RegisterUser {
+mutation Register {
   register(
     input: {
       email: "john@example.com"
@@ -37,7 +47,7 @@ mutation RegisterUser {
 }
 ```
 
-**Response:**
+**Відповідь:**
 
 ```json
 {
@@ -51,10 +61,10 @@ mutation RegisterUser {
 }
 ```
 
-#### 2. Login User
+### 2. Авторизація
 
 ```graphql
-mutation LoginUser {
+mutation Login {
   login(input: { email: "john@example.com", password: "securePassword123" }) {
     accessToken
     userId
@@ -63,15 +73,15 @@ mutation LoginUser {
 }
 ```
 
-#### 3. Health Check
+### 3. Ping перевірка
 
 ```graphql
-query HealthCheck {
+query {
   ping
 }
 ```
 
-**Response:**
+**Відповідь:**
 
 ```json
 {
@@ -122,316 +132,266 @@ query HealthCheck {
 }
 ```
 
-## 👤 User Service (REST)
+## 👤 Управління користувачами
 
-### Base URL: http://localhost:5001
+### Авторизація для захищених операцій
 
-### Authentication
-
-Всі захищені endpoints потребують JWT токен у заголовку:
-
-```
-Authorization: Bearer <jwt-token>
-```
-
-### Endpoints
-
-#### Health Check
-
-```http
-GET /health
-```
-
-**Response:**
+Додайте JWT токен в HTTP заголовки GraphQL Playground:
 
 ```json
 {
-  "status": "ok"
+  "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
 }
 ```
 
-#### Get User Profile
+### 1. Створення користувача
 
-```http
-GET /users/profile
-Authorization: Bearer <jwt-token>
-```
-
-**Response:**
-
-```json
-{
-  "id": "64f1a2b3c4d5e6f7g8h9i0j1",
-  "email": "john@example.com",
-  "name": "John Doe",
-  "profilePicture": null,
-  "phoneNumber": null,
-  "preferences": {
-    "language": "en",
-    "currency": "USD",
-    "notifications": true
-  },
-  "status": "active",
-  "createdAt": "2023-09-01T10:00:00.000Z",
-  "updatedAt": "2023-09-01T10:00:00.000Z"
-}
-```
-
-#### Update User Profile
-
-```http
-PUT /users/profile
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "name": "John Smith",
-  "phoneNumber": "+1234567890",
-  "preferences": {
-    "language": "uk",
-    "currency": "UAH"
-  }
-}
-```
-
-#### Get All Users (Admin Only)
-
-```http
-GET /users
-Authorization: Bearer <admin-jwt-token>
-```
-
-#### Get User by ID (Admin Only)
-
-```http
-GET /users/:id
-Authorization: Bearer <admin-jwt-token>
-```
-
-## 💰 Wallet Service (REST)
-
-### Base URL: http://localhost:5002
-
-### Wallets
-
-#### Create Wallet
-
-```http
-POST /wallets
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "name": "My Main Wallet",
-  "currency": "USD",
-  "type": "personal"
-}
-```
-
-**Response:**
-
-```json
-{
-  "id": "64f1a2b3c4d5e6f7g8h9i0j1",
-  "name": "My Main Wallet",
-  "currency": "USD",
-  "balance": 0,
-  "type": "personal",
-  "status": "active",
-  "isDefault": true,
-  "createdAt": "2023-09-01T10:00:00.000Z"
-}
-```
-
-#### Get My Wallets
-
-```http
-GET /wallets
-Authorization: Bearer <jwt-token>
-```
-
-**Response:**
-
-```json
-[
-  {
-    "id": "64f1a2b3c4d5e6f7g8h9i0j1",
-    "name": "My Main Wallet",
-    "currency": "USD",
-    "balance": 150.5,
-    "type": "personal",
-    "status": "active",
-    "isDefault": true,
-    "createdAt": "2023-09-01T10:00:00.000Z"
-  }
-]
-```
-
-#### Get Wallet by ID
-
-```http
-GET /wallets/:id
-Authorization: Bearer <jwt-token>
-```
-
-#### Update Wallet
-
-```http
-PUT /wallets/:id
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "name": "Updated Wallet Name"
-}
-```
-
-#### Delete Wallet
-
-```http
-DELETE /wallets/:id
-Authorization: Bearer <jwt-token>
-```
-
-### Balance Operations
-
-#### Get Wallet Balance
-
-```http
-GET /wallets/:id/balance
-Authorization: Bearer <jwt-token>
-```
-
-**Response:**
-
-```json
-{
-  "walletId": "64f1a2b3c4d5e6f7g8h9i0j1",
-  "balance": 150.5,
-  "currency": "USD",
-  "lastUpdated": "2023-09-01T12:00:00.000Z"
-}
-```
-
-#### Deposit Money
-
-```http
-POST /wallets/:id/deposit
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "amount": 100.00,
-  "description": "Salary deposit",
-  "reference": "SAL-2023-09-001"
-}
-```
-
-**Response:**
-
-```json
-{
-  "transactionId": "64f1a2b3c4d5e6f7g8h9i0j2",
-  "walletId": "64f1a2b3c4d5e6f7g8h9i0j1",
-  "type": "deposit",
-  "amount": 100.0,
-  "balanceBefore": 50.5,
-  "balanceAfter": 150.5,
-  "currency": "USD",
-  "description": "Salary deposit",
-  "status": "completed",
-  "createdAt": "2023-09-01T12:00:00.000Z"
-}
-```
-
-#### Withdraw Money
-
-```http
-POST /wallets/:id/withdraw
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "amount": 25.00,
-  "description": "ATM withdrawal"
-}
-```
-
-### Transfers
-
-#### Transfer Between Wallets
-
-```http
-POST /wallets/:id/transfer
-Authorization: Bearer <jwt-token>
-Content-Type: application/json
-
-{
-  "toWalletId": "64f1a2b3c4d5e6f7g8h9i0j3",
-  "amount": 50.00,
-  "description": "Payment to friend"
-}
-```
-
-**Response:**
-
-```json
-{
-  "fromTransaction": {
-    "transactionId": "64f1a2b3c4d5e6f7g8h9i0j4",
-    "type": "transfer_out",
-    "amount": -50.0,
-    "balanceAfter": 100.5
-  },
-  "toTransaction": {
-    "transactionId": "64f1a2b3c4d5e6f7g8h9i0j5",
-    "type": "transfer_in",
-    "amount": 50.0,
-    "balanceAfter": 75.0
-  },
-  "status": "completed"
-}
-```
-
-### Transactions
-
-#### Get Transaction History
-
-```http
-GET /wallets/:id/transactions?page=1&limit=10&type=deposit
-Authorization: Bearer <jwt-token>
-```
-
-**Query Parameters:**
-
-- `page` (optional): Page number (default: 1)
-- `limit` (optional): Items per page (default: 10, max: 100)
-- `type` (optional): Transaction type filter
-- `startDate` (optional): Filter from date (ISO string)
-- `endDate` (optional): Filter to date (ISO string)
-
-**Response:**
-
-```json
-{
-  "transactions": [
-    {
-      "id": "64f1a2b3c4d5e6f7g8h9i0j2",
-      "type": "deposit",
-      "amount": 100.0,
-      "balanceBefore": 50.5,
-      "balanceAfter": 150.5,
-      "currency": "USD",
-      "description": "Salary deposit",
-      "status": "completed",
-      "createdAt": "2023-09-01T12:00:00.000Z"
+```graphql
+mutation CreateUser {
+  createUser(
+    createUserInput: {
+      email: "john@example.com"
+      firstName: "John"
+      lastName: "Doe"
+      phone: "+1234567890"
     }
-  ],
-  "pagination": {
-    "page": 1,
-    "limit": 10,
-    "total": 1,
-    "totalPages": 1
+  ) {
+    id
+    email
+    firstName
+    lastName
+    phone
+    isActive
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 2. Отримання всіх користувачів
+
+```graphql
+query GetAllUsers {
+  users {
+    id
+    email
+    firstName
+    lastName
+    phone
+    isActive
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 3. Отримання користувача за ID
+
+```graphql
+query GetUser {
+  user(id: "USER_ID_HERE") {
+    id
+    email
+    firstName
+    lastName
+    phone
+    isActive
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 4. Пошук користувача за email
+
+```graphql
+query GetUserByEmail {
+  userByEmail(email: "john@example.com") {
+    id
+    email
+    firstName
+    lastName
+    phone
+    isActive
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 5. Оновлення користувача
+
+```graphql
+mutation UpdateUser {
+  updateUser(
+    updateUserInput: {
+      id: "USER_ID_HERE"
+      firstName: "Jane"
+      lastName: "Smith"
+      phone: "+0987654321"
+      isActive: true
+    }
+  ) {
+    id
+    email
+    firstName
+    lastName
+    phone
+    isActive
+    updatedAt
+  }
+}
+```
+
+### 6. Видалення користувача
+
+```graphql
+mutation RemoveUser {
+  removeUser(id: "USER_ID_HERE")
+}
+```
+
+## 💰 Управління гаманцями та транзакціями
+
+### 1. Створення гаманця
+
+```graphql
+mutation CreateWallet {
+  createWallet(createWalletInput: { userId: "USER_ID_HERE", currency: USD }) {
+    id
+    userId
+    walletNumber
+    balance
+    currency
+    status
+    blockedAt
+    blockedReason
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Доступні валюти**: `USD`, `EUR`, `UAH`  
+**Статуси**: `ACTIVE`, `BLOCKED`, `SUSPENDED`
+
+### 2. Отримання всіх гаманців
+
+```graphql
+query GetAllWallets {
+  wallets {
+    id
+    userId
+    walletNumber
+    balance
+    currency
+    status
+    blockedAt
+    blockedReason
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 3. Отримання гаманця за ID
+
+```graphql
+query GetWallet {
+  wallet(id: "WALLET_ID_HERE") {
+    id
+    userId
+    walletNumber
+    balance
+    currency
+    status
+    blockedAt
+    blockedReason
+    createdAt
+    updatedAt
+  }
+}
+```
+
+### 4. Поповнення гаманця
+
+```graphql
+mutation TopUpWallet {
+  topUpWallet(
+    topUpInput: {
+      walletId: "WALLET_ID_HERE"
+      amount: 100.50
+      description: "Salary deposit"
+    }
+  ) {
+    id
+    balance
+    updatedAt
+  }
+}
+```
+
+### 5. Переказ між гаманцями
+
+```graphql
+mutation TransferBetweenWallets {
+  transferBetweenWallets(
+    transferInput: {
+      fromWalletId: "FROM_WALLET_ID"
+      toWalletId: "TO_WALLET_ID"
+      amount: 50.00
+      description: "Payment to friend"
+    }
+  ) {
+    id
+    type
+    amount
+    description
+    status
+    createdAt
+  }
+}
+```
+
+**Типи транзакцій**: `TOP_UP`, `TRANSFER`, `WITHDRAWAL`  
+**Статуси транзакцій**: `PENDING`, `COMPLETED`, `FAILED`
+
+### 6. Оновлення статусу гаманця
+
+```graphql
+mutation UpdateWallet {
+  updateWallet(
+    updateWalletInput: {
+      id: "WALLET_ID_HERE"
+      status: BLOCKED
+      blockedReason: "Suspicious activity detected"
+    }
+  ) {
+    id
+    status
+    blockedAt
+    blockedReason
+    updatedAt
+  }
+}
+```
+
+### 7. Отримання транзакцій гаманця
+
+```graphql
+query GetWalletTransactions {
+  wallet(id: "WALLET_ID_HERE") {
+    id
+    walletNumber
+    balance
+    transactions {
+      id
+      type
+      amount
+      description
+      status
+      createdAt
+    }
   }
 }
 ```
@@ -501,174 +461,649 @@ Authorization: Bearer <jwt-token>
 }
 ```
 
-## 📱 Integration Examples
+## 📱 Приклади інтеграції
 
-### Frontend JavaScript
+### Frontend JavaScript (Apollo Client)
 
 ```javascript
+import { ApolloClient, InMemoryCache, createHttpLink } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+import { gql } from "@apollo/client";
+
 class WalletPlatformAPI {
-  constructor(baseURL = "http://localhost") {
-    this.authService = `${baseURL}:5000/graphql`;
-    this.userService = `${baseURL}:5001`;
-    this.walletService = `${baseURL}:5002`;
-    this.token = localStorage.getItem("jwt_token");
-  }
-
-  // Auth Service
-  async login(email, password) {
-    const response = await fetch(this.authService, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        query: `
-          mutation Login($email: String!, $password: String!) {
-            login(input: { email: $email, password: $password }) {
-              accessToken
-              userId
-              roles
-            }
-          }
-        `,
-        variables: { email, password },
-      }),
+  constructor(gatewayURL = "http://localhost:4000/graphql") {
+    // HTTP Link до Gateway Service
+    const httpLink = createHttpLink({
+      uri: gatewayURL,
     });
 
-    const data = await response.json();
-    if (data.data?.login?.accessToken) {
-      this.token = data.data.login.accessToken;
-      localStorage.setItem("jwt_token", this.token);
-    }
-    return data;
-  }
-
-  // User Service
-  async getProfile() {
-    const response = await fetch(`${this.userService}/users/profile`, {
-      headers: { Authorization: `Bearer ${this.token}` },
-    });
-    return response.json();
-  }
-
-  // Wallet Service
-  async createWallet(name, currency) {
-    const response = await fetch(`${this.walletService}/wallets`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name, currency }),
-    });
-    return response.json();
-  }
-
-  async transfer(fromWalletId, toWalletId, amount, description) {
-    const response = await fetch(
-      `${this.walletService}/wallets/${fromWalletId}/transfer`,
-      {
-        method: "POST",
+    // Auth Link для додавання JWT токена
+    const authLink = setContext((_, { headers }) => {
+      const token = localStorage.getItem("jwt_token");
+      return {
         headers: {
-          Authorization: `Bearer ${this.token}`,
-          "Content-Type": "application/json",
+          ...headers,
+          authorization: token ? `Bearer ${token}` : "",
         },
-        body: JSON.stringify({ toWalletId, amount, description }),
+      };
+    });
+
+    // Apollo Client
+    this.client = new ApolloClient({
+      link: authLink.concat(httpLink),
+      cache: new InMemoryCache(),
+    });
+  }
+
+  // Авторизація
+  async login(email, password) {
+    const LOGIN_MUTATION = gql`
+      mutation Login($email: String!, $password: String!) {
+        login(input: { email: $email, password: $password }) {
+          accessToken
+          userId
+          roles
+        }
       }
-    );
-    return response.json();
+    `;
+
+    const { data } = await this.client.mutate({
+      mutation: LOGIN_MUTATION,
+      variables: { email, password },
+    });
+
+    if (data.login.accessToken) {
+      localStorage.setItem("jwt_token", data.login.accessToken);
+    }
+
+    return data.login;
+  }
+
+  // Створення користувача
+  async createUser(email, firstName, lastName, phone) {
+    const CREATE_USER_MUTATION = gql`
+      mutation CreateUser($input: CreateUserInput!) {
+        createUser(createUserInput: $input) {
+          id
+          email
+          firstName
+          lastName
+          phone
+          isActive
+        }
+      }
+    `;
+
+    const { data } = await this.client.mutate({
+      mutation: CREATE_USER_MUTATION,
+      variables: {
+        input: { email, firstName, lastName, phone },
+      },
+    });
+
+    return data.createUser;
+  }
+
+  // Створення гаманця
+  async createWallet(userId, currency = "USD") {
+    const CREATE_WALLET_MUTATION = gql`
+      mutation CreateWallet($input: CreateWalletInput!) {
+        createWallet(createWalletInput: $input) {
+          id
+          userId
+          walletNumber
+          balance
+          currency
+          status
+        }
+      }
+    `;
+
+    const { data } = await this.client.mutate({
+      mutation: CREATE_WALLET_MUTATION,
+      variables: {
+        input: { userId, currency },
+      },
+    });
+
+    return data.createWallet;
+  }
+
+  // Поповнення гаманця
+  async topUpWallet(walletId, amount, description) {
+    const TOP_UP_MUTATION = gql`
+      mutation TopUpWallet($input: TopUpInput!) {
+        topUpWallet(topUpInput: $input) {
+          id
+          balance
+          updatedAt
+        }
+      }
+    `;
+
+    const { data } = await this.client.mutate({
+      mutation: TOP_UP_MUTATION,
+      variables: {
+        input: { walletId, amount, description },
+      },
+    });
+
+    return data.topUpWallet;
+  }
+
+  // Переказ між гаманцями
+  async transfer(fromWalletId, toWalletId, amount, description) {
+    const TRANSFER_MUTATION = gql`
+      mutation TransferBetweenWallets($input: TransferInput!) {
+        transferBetweenWallets(transferInput: $input) {
+          id
+          type
+          amount
+          description
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const { data } = await this.client.mutate({
+      mutation: TRANSFER_MUTATION,
+      variables: {
+        input: { fromWalletId, toWalletId, amount, description },
+      },
+    });
+
+    return data.transferBetweenWallets;
+  }
+
+  // Отримання гаманців користувача
+  async getWallets() {
+    const GET_WALLETS_QUERY = gql`
+      query GetWallets {
+        wallets {
+          id
+          userId
+          walletNumber
+          balance
+          currency
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const { data } = await this.client.query({
+      query: GET_WALLETS_QUERY,
+    });
+
+    return data.wallets;
   }
 }
 
-// Usage
+// Використання
 const api = new WalletPlatformAPI();
 
-// Login
-await api.login("john@example.com", "password123");
+async function example() {
+  try {
+    // 1. Авторизація
+    const authResult = await api.login("john@example.com", "password123");
+    console.log("Logged in:", authResult);
 
-// Create wallet
-const wallet = await api.createWallet("My Wallet", "USD");
+    // 2. Створення користувача
+    const user = await api.createUser(
+      "john@example.com",
+      "John",
+      "Doe",
+      "+1234567890"
+    );
+    console.log("User created:", user);
 
-// Transfer money
-await api.transfer(wallet.id, "other-wallet-id", 50.0, "Payment");
+    // 3. Створення гаманця
+    const wallet = await api.createWallet(authResult.userId, "USD");
+    console.log("Wallet created:", wallet);
+
+    // 4. Поповнення гаманця
+    const topUp = await api.topUpWallet(wallet.id, 1000.0, "Initial deposit");
+    console.log("Wallet topped up:", topUp);
+
+    // 5. Отримання всіх гаманців
+    const wallets = await api.getWallets();
+    console.log("All wallets:", wallets);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+example();
 ```
 
-### Python Client
+### TypeScript/Node.js Client (GraphQL-Request)
 
-```python
-import requests
-import json
+```typescript
+import { GraphQLClient, gql } from "graphql-request";
 
-class WalletPlatformClient:
-    def __init__(self, base_url="http://localhost"):
-        self.auth_service = f"{base_url}:5000/graphql"
-        self.user_service = f"{base_url}:5001"
-        self.wallet_service = f"{base_url}:5002"
-        self.token = None
+interface AuthResult {
+  accessToken: string;
+  userId: string;
+  roles: string[];
+}
 
-    def login(self, email, password):
-        query = """
-        mutation Login($email: String!, $password: String!) {
-            login(input: { email: $email, password: $password }) {
-                accessToken
-                userId
-                roles
-            }
+interface User {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone?: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+interface Wallet {
+  id: string;
+  userId: string;
+  walletNumber: string;
+  balance: number;
+  currency: string;
+  status: string;
+  createdAt: string;
+}
+
+interface Transaction {
+  id: string;
+  type: string;
+  amount: number;
+  description?: string;
+  status: string;
+  createdAt: string;
+}
+
+export class WalletPlatformClient {
+  private client: GraphQLClient;
+  private token: string | null = null;
+
+  constructor(gatewayUrl = "http://localhost:4000/graphql") {
+    this.client = new GraphQLClient(gatewayUrl);
+  }
+
+  private setAuthToken(token: string): void {
+    this.token = token;
+    this.client.setHeaders({
+      authorization: `Bearer ${token}`,
+    });
+  }
+
+  // Авторизація
+  async login(email: string, password: string): Promise<AuthResult> {
+    const mutation = gql`
+      mutation Login($email: String!, $password: String!) {
+        login(input: { email: $email, password: $password }) {
+          accessToken
+          userId
+          roles
         }
-        """
+      }
+    `;
 
-        response = requests.post(
-            self.auth_service,
-            json={
-                "query": query,
-                "variables": {"email": email, "password": password}
-            }
-        )
+    const data = await this.client.request(mutation, { email, password });
+    const authResult = data.login as AuthResult;
 
-        data = response.json()
-        if data.get("data", {}).get("login", {}).get("accessToken"):
-            self.token = data["data"]["login"]["accessToken"]
+    if (authResult.accessToken) {
+      this.setAuthToken(authResult.accessToken);
+    }
 
-        return data
+    return authResult;
+  }
 
-    def get_wallets(self):
-        headers = {"Authorization": f"Bearer {self.token}"}
-        response = requests.get(f"{self.wallet_service}/wallets", headers=headers)
-        return response.json()
-
-    def deposit(self, wallet_id, amount, description):
-        headers = {
-            "Authorization": f"Bearer {self.token}",
-            "Content-Type": "application/json"
+  // Реєстрація
+  async register(
+    email: string,
+    password: string,
+    name?: string
+  ): Promise<AuthResult> {
+    const mutation = gql`
+      mutation Register($input: RegisterInput!) {
+        register(input: $input) {
+          accessToken
+          userId
+          roles
         }
-        data = {"amount": amount, "description": description}
+      }
+    `;
 
-        response = requests.post(
-            f"{self.wallet_service}/wallets/{wallet_id}/deposit",
-            headers=headers,
-            json=data
-        )
-        return response.json()
+    const data = await this.client.request(mutation, {
+      input: { email, password, name },
+    });
 
-# Usage
-client = WalletPlatformClient()
-client.login("john@example.com", "password123")
-wallets = client.get_wallets()
-client.deposit(wallets[0]["id"], 100.0, "Initial deposit")
+    const authResult = data.register as AuthResult;
+
+    if (authResult.accessToken) {
+      this.setAuthToken(authResult.accessToken);
+    }
+
+    return authResult;
+  }
+
+  // Створення користувача
+  async createUser(
+    email: string,
+    firstName: string,
+    lastName: string,
+    phone?: string
+  ): Promise<User> {
+    const mutation = gql`
+      mutation CreateUser($input: CreateUserInput!) {
+        createUser(createUserInput: $input) {
+          id
+          email
+          firstName
+          lastName
+          phone
+          isActive
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(mutation, {
+      input: { email, firstName, lastName, phone },
+    });
+
+    return data.createUser as User;
+  }
+
+  // Отримання користувачів
+  async getUsers(): Promise<User[]> {
+    const query = gql`
+      query GetUsers {
+        users {
+          id
+          email
+          firstName
+          lastName
+          phone
+          isActive
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(query);
+    return data.users as User[];
+  }
+
+  // Отримання користувача за ID
+  async getUserById(id: string): Promise<User> {
+    const query = gql`
+      query GetUser($id: String!) {
+        user(id: $id) {
+          id
+          email
+          firstName
+          lastName
+          phone
+          isActive
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(query, { id });
+    return data.user as User;
+  }
+
+  // Створення гаманця
+  async createWallet(userId: string, currency = "USD"): Promise<Wallet> {
+    const mutation = gql`
+      mutation CreateWallet($input: CreateWalletInput!) {
+        createWallet(createWalletInput: $input) {
+          id
+          userId
+          walletNumber
+          balance
+          currency
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(mutation, {
+      input: { userId, currency },
+    });
+
+    return data.createWallet as Wallet;
+  }
+
+  // Отримання всіх гаманців
+  async getWallets(): Promise<Wallet[]> {
+    const query = gql`
+      query GetWallets {
+        wallets {
+          id
+          userId
+          walletNumber
+          balance
+          currency
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(query);
+    return data.wallets as Wallet[];
+  }
+
+  // Отримання гаманця за ID
+  async getWalletById(id: string): Promise<Wallet> {
+    const query = gql`
+      query GetWallet($id: String!) {
+        wallet(id: $id) {
+          id
+          userId
+          walletNumber
+          balance
+          currency
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(query, { id });
+    return data.wallet as Wallet;
+  }
+
+  // Поповнення гаманця
+  async topUpWallet(
+    walletId: string,
+    amount: number,
+    description?: string
+  ): Promise<Wallet> {
+    const mutation = gql`
+      mutation TopUpWallet($input: TopUpInput!) {
+        topUpWallet(topUpInput: $input) {
+          id
+          balance
+          updatedAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(mutation, {
+      input: { walletId, amount, description },
+    });
+
+    return data.topUpWallet as Wallet;
+  }
+
+  // Переказ між гаманцями
+  async transferBetweenWallets(
+    fromWalletId: string,
+    toWalletId: string,
+    amount: number,
+    description?: string
+  ): Promise<Transaction> {
+    const mutation = gql`
+      mutation TransferBetweenWallets($input: TransferInput!) {
+        transferBetweenWallets(transferInput: $input) {
+          id
+          type
+          amount
+          description
+          status
+          createdAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(mutation, {
+      input: { fromWalletId, toWalletId, amount, description },
+    });
+
+    return data.transferBetweenWallets as Transaction;
+  }
+
+  // Оновлення статусу гаманця
+  async updateWallet(
+    id: string,
+    status?: string,
+    blockedReason?: string
+  ): Promise<Wallet> {
+    const mutation = gql`
+      mutation UpdateWallet($input: UpdateWalletInput!) {
+        updateWallet(updateWalletInput: $input) {
+          id
+          status
+          blockedAt
+          blockedReason
+          updatedAt
+        }
+      }
+    `;
+
+    const data = await this.client.request(mutation, {
+      input: { id, status, blockedReason },
+    });
+
+    return data.updateWallet as Wallet;
+  }
+}
+
+// Використання
+async function example() {
+  const client = new WalletPlatformClient();
+
+  try {
+    // 1. Реєстрація або авторизація
+    const authResult = await client.login("john@example.com", "password123");
+    console.log("Logged in:", authResult);
+
+    // 2. Створення користувача
+    const user = await client.createUser(
+      "john@example.com",
+      "John",
+      "Doe",
+      "+1234567890"
+    );
+    console.log("User created:", user);
+
+    // 3. Створення гаманця
+    const wallet = await client.createWallet(authResult.userId, "USD");
+    console.log("Wallet created:", wallet);
+
+    // 4. Поповнення гаманця
+    const topUpResult = await client.topUpWallet(
+      wallet.id,
+      1000.0,
+      "Initial deposit"
+    );
+    console.log("Wallet topped up:", topUpResult);
+
+    // 5. Отримання всіх гаманців
+    const wallets = await client.getWallets();
+    console.log("All wallets:", wallets);
+
+    // 6. Переказ між гаманцями (якщо є два гаманці)
+    if (wallets.length >= 2) {
+      const transferResult = await client.transferBetweenWallets(
+        wallets[0].id,
+        wallets[1].id,
+        100.0,
+        "Test transfer"
+      );
+      console.log("Transfer completed:", transferResult);
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+// Запуск прикладу
+example();
 ```
 
-## 🔗 Postman Collection
+### Встановлення залежностей
 
-Створіть Postman collection з цими endpoints для тестування API:
+```bash
+# Для TypeScript проекту
+npm install graphql-request graphql
+
+# Для розробки
+npm install -D @types/node typescript ts-node
+```
+
+### package.json
+
+```json
+{
+  "name": "wallet-platform-client",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "ts-node example.ts",
+    "build": "tsc",
+    "start": "node dist/example.js"
+  },
+  "dependencies": {
+    "graphql": "^16.8.1",
+    "graphql-request": "^6.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}
+```
+
+## 🔗 Інструменти для тестування
+
+### GraphQL Playground (Рекомендовано)
+
+**URL**: http://localhost:4000/graphql
+
+Найкращий спосіб тестування - використовуйте вбудований GraphQL Playground:
+
+- Автоматична документація всіх операцій
+- Introspection схеми
+- Автокомпліт та валідація
+- Історія запитів
+- Можливість додавання HTTP заголовків
+
+### Postman Collection
+
+Створіть Postman collection для GraphQL тестування:
 
 ```json
 {
   "info": {
-    "name": "Wallet Platform API",
-    "description": "Complete API collection for Wallet Platform"
+    "name": "Wallet Platform GraphQL API",
+    "description": "Complete GraphQL API collection через Gateway Service"
   },
   "variable": [
     {
-      "key": "base_url",
-      "value": "http://localhost"
+      "key": "gateway_url",
+      "value": "http://localhost:4000/graphql"
     },
     {
       "key": "jwt_token",
@@ -677,19 +1112,112 @@ client.deposit(wallets[0]["id"], 100.0, "Initial deposit")
   ],
   "item": [
     {
-      "name": "Auth Service",
+      "name": "Authentication",
       "item": [
         {
           "name": "Login",
           "request": {
             "method": "POST",
-            "url": "{{base_url}}:5000/graphql",
-            "body": {
-              "mode": "graphql",
-              "graphql": {
-                "query": "mutation Login($email: String!, $password: String!) {\n  login(input: { email: $email, password: $password }) {\n    accessToken\n    userId\n    roles\n  }\n}",
-                "variables": "{\n  \"email\": \"john@example.com\",\n  \"password\": \"password123\"\n}"
+            "url": "{{gateway_url}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
               }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"mutation Login($email: String!, $password: String!) { login(input: { email: $email, password: $password }) { accessToken userId roles } }\",\n  \"variables\": {\n    \"email\": \"john@example.com\",\n    \"password\": \"password123\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST",
+            "url": "{{gateway_url}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"mutation Register($input: RegisterInput!) { register(input: $input) { accessToken userId roles } }\",\n  \"variables\": {\n    \"input\": {\n      \"email\": \"john@example.com\",\n      \"password\": \"password123\",\n      \"name\": \"John Doe\"\n    }\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "User Management",
+      "item": [
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "url": "{{gateway_url}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"mutation CreateUser($input: CreateUserInput!) { createUser(createUserInput: $input) { id email firstName lastName phone isActive } }\",\n  \"variables\": {\n    \"input\": {\n      \"email\": \"john@example.com\",\n      \"firstName\": \"John\",\n      \"lastName\": \"Doe\",\n      \"phone\": \"+1234567890\"\n    }\n  }\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Wallet Management",
+      "item": [
+        {
+          "name": "Create Wallet",
+          "request": {
+            "method": "POST",
+            "url": "{{gateway_url}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"mutation CreateWallet($input: CreateWalletInput!) { createWallet(createWalletInput: $input) { id userId walletNumber balance currency status } }\",\n  \"variables\": {\n    \"input\": {\n      \"userId\": \"USER_ID_HERE\",\n      \"currency\": \"USD\"\n    }\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "Top Up Wallet",
+          "request": {
+            "method": "POST",
+            "url": "{{gateway_url}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"mutation TopUpWallet($input: TopUpInput!) { topUpWallet(topUpInput: $input) { id balance updatedAt } }\",\n  \"variables\": {\n    \"input\": {\n      \"walletId\": \"WALLET_ID_HERE\",\n      \"amount\": 100.0,\n      \"description\": \"Test deposit\"\n    }\n  }\n}"
             }
           }
         }
@@ -699,6 +1227,59 @@ client.deposit(wallets[0]["id"], 100.0, "Initial deposit")
 }
 ```
 
+### cURL приклади
+
+```bash
+# Авторизація
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "mutation Login($email: String!, $password: String!) { login(input: { email: $email, password: $password }) { accessToken userId roles } }",
+    "variables": {
+      "email": "john@example.com",
+      "password": "password123"
+    }
+  }'
+
+# Створення користувача (з JWT токеном)
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "query": "mutation CreateUser($input: CreateUserInput!) { createUser(createUserInput: $input) { id email firstName lastName } }",
+    "variables": {
+      "input": {
+        "email": "john@example.com",
+        "firstName": "John",
+        "lastName": "Doe"
+      }
+    }
+  }'
+```
+
 ---
 
-**💡 Tip**: Використовуйте GraphQL Playground для тестування Auth Service та інструменти типу Postman або Insomnia для REST API.
+## 📚 Додаткові ресурси
+
+### Документація
+
+- **[Повний посібник з тестування](TESTING_GRAPHQL.md)** - детальні інструкції з тестування
+- **[Docker інструкції](DOCKER.md)** - налаштування та запуск через Docker
+- **[README проекту](../README.md)** - загальна інформація про проект
+
+### GraphQL ресурси
+
+- [GraphQL офіційна документація](https://graphql.org/)
+- [Apollo Federation документація](https://www.apollographql.com/docs/federation/)
+- [Apollo Client документація](https://www.apollographql.com/docs/react/)
+
+### Інструменти розробки
+
+- **GraphQL Playground**: http://localhost:4000/graphql
+- **RabbitMQ Management**: http://localhost:15672
+- **Prometheus** (опціонально): http://localhost:9090
+- **Grafana** (опціонально): http://localhost:3000
+
+---
+
+**💡 Рекомендація**: Для швидкого тестування використовуйте GraphQL Playground. Для автоматизованого тестування - Apollo Client або Python/JavaScript клієнти з цієї документації.

--- a/services/auth-service/src/app.controller.ts
+++ b/services/auth-service/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/services/auth-service/src/app.module.ts
+++ b/services/auth-service/src/app.module.ts
@@ -8,6 +8,8 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { HealthController } from './health/health.controller';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
 
 @Module({
   imports: [
@@ -27,6 +29,7 @@ import { HealthController } from './health/health.controller';
     AuthModule,
     UsersModule,
   ],
-  controllers: [HealthController],
+  controllers: [HealthController, AppController],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/services/auth-service/src/app.service.ts
+++ b/services/auth-service/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Auth Service is running!';
+  }
+}


### PR DESCRIPTION
docs: update API documentation for Apollo Federation architecture

- Replace Python client examples with TypeScript client using graphql-request
- Update service ports (3000-3002 → 4000 gateway)  
- Convert REST API examples to GraphQL operations
- Add proper TypeScript interfaces and type safety
- Update README.md with current service architecture
- Fix code formatting and consistency